### PR TITLE
fix: write to balanced layout at width

### DIFF
--- a/src/file/layout/balanced.js
+++ b/src/file/layout/balanced.js
@@ -51,13 +51,13 @@ import * as Chunker from "./../chunker/api.js"
  *                                                           |
  *                                    ------------------------------------------
  *                                    |                                        |
- *                                  (root4)                                  (root6)
+ *                                 (root4)                                  (root6)
  *                                    |                                        |
- *              ----------------------------------------------                 |
- *              |                     |                       |                |
- *           (root1)               (root2)                 (root3)          (root5)
- *              |                     |                       |                |
- *    -----------------       --------|--------       -----------------        |
+ *            -------------------------------------------------                |
+ *            |                       |                       |                |
+ *         (root1)                 (root2)                 (root3)          (root5)
+ *            |                       |                       |                |
+ *    --------|--------       --------|--------       --------|--------        |
  *    |       |       |       |       |       |       |       |       |        |
  * (leaf1) (leaf2) (leaf3) (leaf4) (leaf5) (leaf6) (leaf7) (leaf8) (leaf9) (leaf10)
  * ```
@@ -176,7 +176,7 @@ export const write = (layout, chunks) => {
         leafIndex.push(leaf.id)
       }
 
-      if (leafIndex.length >= layout.width) {
+      if (leafIndex.length > layout.width) {
         return flush({ ...layout, leafIndex, head, lastID }, leaves)
       } else {
         return {
@@ -203,7 +203,7 @@ export const flush = (state, leaves = EMPTY, nodes = [], close = false) => {
   const { width } = state
 
   // Move leaves into nodes
-  while (leafIndex.length >= width || (leafIndex.length > 0 && close)) {
+  while (leafIndex.length > width || (leafIndex.length > 0 && close)) {
     grow(nodeIndex, 1)
     const node = new Node(++lastID, leafIndex.splice(0, width))
     nodeIndex[0].push(node.id)
@@ -216,7 +216,7 @@ export const flush = (state, leaves = EMPTY, nodes = [], close = false) => {
     depth++
 
     while (
-      row.length >= width ||
+      row.length > width ||
       (row.length > 0 && close && depth < nodeIndex.length)
     ) {
       const node = new Node(++lastID, row.splice(0, width))

--- a/test/file/layout/balanced.spec.js
+++ b/test/file/layout/balanced.spec.js
@@ -124,4 +124,72 @@ describe("balanced layout", () => {
       })
     }
   })
+
+  it("overflows into second node at width boundary", () => {
+    let balanced = Balanced.open({ width: 3 })
+    {
+      const { nodes, leaves, layout } = Balanced.write(balanced, [
+        Slice.create([], 0, 4),
+        Slice.create([], 4, 8),
+        Slice.create([], 8, 16),
+      ])
+      assert.deepEqual(nodes, [])
+      assert.deepEqual(leaves, [
+        {
+          id: 1,
+          content: Slice.create([], 0, 4),
+        },
+        {
+          id: 2,
+          content: Slice.create([], 4, 8),
+        },
+        {
+          id: 3,
+          content: Slice.create([], 8, 16),
+        }
+      ])
+
+      balanced = layout
+    }
+
+    {
+      const { nodes, leaves, layout } = Balanced.write(balanced, [
+        Slice.create([], 16, 28),
+      ])
+      assert.deepEqual(leaves, [
+        {
+          id: 4,
+          content: Slice.create([], 16, 28),
+        }
+      ])
+
+      assert.deepEqual(nodes, [
+        {
+          id: 5,
+          children: [1, 2, 3],
+          metadata: undefined,
+        },
+      ])
+
+      balanced = layout
+    }
+
+    {
+      const { root, nodes, leaves } = Balanced.close(balanced, {})
+      assert.deepEqual(leaves, [])
+      assert.deepEqual(nodes, [
+        {
+          id: 6,
+          children: [4],
+          metadata: undefined,
+        },
+      ])
+
+      assert.deepEqual(root, {
+        id: 7,
+        children: [5, 6],
+        metadata: {},
+      })
+    }
+  })
 })


### PR DESCRIPTION
Fixes a bug that occurs when writing chunks to a balanced layout when the chunks to be written cause the number of leaves to fall _on_ the `width` boundary.

I was seeing this file link come out when adding a 1GiB file:

```js
{
  cid: CID(bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku),
  contentByteLength: 0,
  dagByteLength: 0
}
```

When using settings:

```js
const settings = UnixFS.configure({
  fileChunkEncoder: raw,
  smallFileEncoder: raw,
  chunker: withMaxChunkSize(1024 * 1024),
  fileLayout: withWidth(1024),
})
```

Note that widths that are multiples of the chunk size also exhibit the behaviour e.g. `512`, `128` etc. NOT `2048` though as this does not trigger the layout to do any work to rebalance.

For completeness, this is what is expected:

```js
{
  cid: CID(bafybeigpyaqbbvedzatazfw6jf5daalt4tcegmqsmi32nlhdvvrw72ybea),
  contentByteLength: 1073741824,
  dagByteLength: 1073793035
}
```

Test code:

```js
import fs from 'node:fs'
import { Readable } from 'node:stream'
import * as UnixFS from '@ipld/unixfs'
import * as raw from 'multiformats/codecs/raw'
import { withMaxChunkSize } from '@ipld/unixfs/file/chunker/fixed'
import { withWidth } from '@ipld/unixfs/file/layout/balanced'

const settings = UnixFS.configure({
  fileChunkEncoder: raw,
  smallFileEncoder: raw,
  chunker: withMaxChunkSize(1024 * 1024),
  fileLayout: withWidth(1024),
})

const queuingStrategy = UnixFS.withCapacity()

async function main () {
  console.log('start')
  const stream = Readable.toWeb(fs.createReadStream('./1GiB.bin'))
  const { readable, writable } = new TransformStream(undefined, queuingStrategy)
  ;(async () => {
    await readable.pipeTo(new WritableStream())
  })()
  const writer = UnixFS.createWriter({ writable, settings })
  const file = UnixFS.createFileWriter(writer)
  await stream.pipeTo(new WritableStream({
    async write (chunk) {
      await file.write(chunk)
    }
  }))
  const link = await file.close()
  console.log('file', link)

  const dir = UnixFS.createDirectoryWriter(writer)
  dir.set('1GiB.bin', link)
  const dirLink = await dir.close()
  console.log('dir', dirLink)

  console.log('end')
}

main()
```